### PR TITLE
Security: CORS Fixed Again

### DIFF
--- a/src/main/java/com/nullteam6/config/SecurityConfig.java
+++ b/src/main/java/com/nullteam6/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         super.configure(http);
+        http.cors();
         http.csrf().disable();
         http.authorizeRequests().antMatchers("/user/**").hasRole("USER");
         http.authorizeRequests().antMatchers("/profile/**").hasRole("USER");

--- a/src/main/java/com/nullteam6/controller/AnimeController.java
+++ b/src/main/java/com/nullteam6/controller/AnimeController.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/anime")
+@CrossOrigin
 public class AnimeController {
 
     private AnimeService service;

--- a/src/main/java/com/nullteam6/controller/CategoryController.java
+++ b/src/main/java/com/nullteam6/controller/CategoryController.java
@@ -6,16 +6,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.util.List;
 
 @RestController
+@CrossOrigin
 @RequestMapping("/category")
 public class CategoryController {
 

--- a/src/main/java/com/nullteam6/controller/LoginController.java
+++ b/src/main/java/com/nullteam6/controller/LoginController.java
@@ -13,6 +13,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.security.NoSuchAlgorithmException;
 
 @RestController
+@CrossOrigin
 @RequestMapping("/login")
 public class LoginController {
 

--- a/src/main/java/com/nullteam6/controller/ProfileController.java
+++ b/src/main/java/com/nullteam6/controller/ProfileController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@CrossOrigin
 @RequestMapping("/profile")
 public class ProfileController {
 

--- a/src/main/java/com/nullteam6/controller/UserController.java
+++ b/src/main/java/com/nullteam6/controller/UserController.java
@@ -15,6 +15,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.security.NoSuchAlgorithmException;
 
 @RestController
+@CrossOrigin
 @RequestMapping("/user")
 public class UserController {
 

--- a/src/main/webapp/WEB-INF/keycloak.json
+++ b/src/main/webapp/WEB-INF/keycloak.json
@@ -1,7 +1,7 @@
 {
   "realm": "miro",
   "bearer-only": true,
-  "auth-server-url": "http://miro.5x5code.com:8085/auth/",
+  "auth-server-url": "https://miro.5x5code.com:8445/auth/",
   "ssl-required": "external",
   "resource": "spring",
   "confidential-port": 0

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -19,20 +19,4 @@
     <servlet-name>BackEnd</servlet-name>
     <url-pattern>/*</url-pattern>
   </servlet-mapping>
-  <filter>
-    <filter-name>CorsFilter</filter-name>
-    <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>
-    <init-param>
-      <param-name>cors.allowed.origins</param-name>
-      <param-value>*</param-value>
-    </init-param>
-    <init-param>
-      <param-name>cors.allowed.methods</param-name>
-      <param-value>GET,POST,HEAD,OPTIONS,PUT</param-value>
-    </init-param>
-  </filter>
-  <filter-mapping>
-    <filter-name>CorsFilter</filter-name>
-    <url-pattern>/*</url-pattern>
-  </filter-mapping>
 </web-app>


### PR DESCRIPTION
Dumped Tomcat CORS Filtering as it ended up adding an additional Access-Control-Allowed-Origins header which was getting requests denied. Added a basic CORS configuration to Spring Security to enable preflight requests. Added @CrossOrigin annotation to all Spring MVC controllers.

Signed-off-by: Gilbert Turner <grturner@5x5code.com>